### PR TITLE
chore: upgrade kibo-paymentgateway-hosting to 0.2.0 and fix associated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@kibocommerce/kibo-paymentgateway-hosting": "^0.1.2",
+    "@kibocommerce/kibo-paymentgateway-hosting": "^0.2.0",
     "convict": "^6.2.1"
   }
 }

--- a/src/CustomGatewayAdapter.ts
+++ b/src/CustomGatewayAdapter.ts
@@ -18,6 +18,8 @@ import type {
   GatewayInteraction,
   ValidateResponse,
 } from '@kibocommerce/kibo-paymentgateway-hosting'
+import { SessionRequest } from '@kibocommerce/kibo-paymentgateway-hosting/dist/types/models/SessionRequest'
+import { SessionResponse } from '@kibocommerce/kibo-paymentgateway-hosting/dist/types/models/SessionResponse'
 import type { CustomAdapterSettings } from './types'
 export class CustomGatewayAdapter implements PaymentGatwayAdapter {
   context: AdapterContext
@@ -74,6 +76,9 @@ export class CustomGatewayAdapter implements PaymentGatwayAdapter {
     throw new Error('Method not implemented.')
   }
   async getAuthorizationIDKeyName(): Promise<AuthorizeIdKeyNameResponse> {
+    throw new Error('Method not implemented.')
+  }
+  async session(request: SessionRequest): Promise<SessionResponse> {
     throw new Error('Method not implemented.')
   }
 }


### PR DESCRIPTION
- Update package.json (side note: we really should have package-lock.json be part of this for better tracking on minor version changes from the dependencies)
- Implement session method needed by 0.2.0 version of the hosting. Note, the SessionRequest and SessionResponse were not in the main export of '@kibocommerce/kibo-paymentgateway-hosting', that's why I had to dig them out.